### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`elliotkirk` is the personal website (elliotkirk.com): a React + TypeScript single-page app
+bundled with webpack. Standard scripts live in `package.json` (`yarn start`, `yarn build`).
+
+Service / dev workflow notes (non-obvious bits only):
+
+- Node 24 is required (`.nvmrc` / `engines.node >= 24`) and the package manager is **yarn classic**
+  (enabled through corepack). The startup update script already installs Node 24 and runs
+  `yarn install`.
+- PATH gotcha: the base image ships a `/exec-daemon/node` (Node 22) that shadows the nvm-managed
+  Node 24 even after `nvm use 24`. Before running `yarn`, prepend the nvm bin to PATH so the right
+  node is used, e.g.:
+  `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 24; export PATH="$NVM_DIR/versions/node/v24.18.0/bin:$PATH"`.
+  Without this, commands silently run under Node 22.
+- Run (dev): `yarn start` launches `webpack-dev-server` at http://localhost:8080/. The script
+  passes `--open`, which just tries to open a browser and is harmless in a headless VM.
+- Build: `yarn build` (webpack) emits to `public/`.
+- The `@grafana/faro-*` dependencies are vendored as local tarballs in `faro-vendor/`; `yarn`
+  resolves them from disk, so no registry access is needed for those.
+- Tests: there is no real test suite (`yarn test` is a placeholder that exits 1).
+- Lint: there is no `lint` script; run ESLint directly with `npx eslint src --ext .ts,.tsx`.
+  Note: ESLint currently reports one pre-existing error (`react/react-in-jsx-scope` in
+  `src/index.tsx`) because the eslint config predates the new JSX runtime. This is a known
+  code/config issue, not an environment problem.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the `elliotkirk` web app so Cloud Agents can build, lint, and run it reliably.

Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious setup/run details:
- Node 24 + yarn (corepack) requirement.
- PATH gotcha where the base image's `/exec-daemon/node` (Node 22) shadows nvm's Node 24.
- Dev/build/lint commands and the vendored `@grafana/faro-*` tarballs.
- The pre-existing `react/react-in-jsx-scope` ESLint error (code/config, not environment).

No application code is modified.

## Verification

- `yarn install` — installs cleanly (Node 24).
- `npx eslint src --ext .ts,.tsx` — ESLint runs (one pre-existing `react/react-in-jsx-scope` error).
- `yarn build` — webpack compiles successfully to `public/`.
- `yarn start` — dev server serves at http://localhost:8080/; verified the page renders and the matter-js balls physics demo is interactive.

[elliotkirk_balls_physics_demo.mp4](https://cursor.com/agents/bc-c366481b-3bb9-46e1-82b4-dc954bd19f56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felliotkirk_balls_physics_demo.mp4)

[elliotkirk web app rendered](https://cursor.com/agents/bc-c366481b-3bb9-46e1-82b4-dc954bd19f56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felliotkirk_webapp.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c366481b-3bb9-46e1-82b4-dc954bd19f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c366481b-3bb9-46e1-82b4-dc954bd19f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

