### PR TITLE
docs: add AGENTS.md with Cursor Cloud setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`elliotkirk` is a personal website: React 18 + TypeScript bundled with webpack 5. It is a
+static single-page app (no backend).
+
+### Toolchain
+- Requires Node 24 (`.nvmrc` / `engines.node >=24`). Node is installed via `nvm`; the
+  startup update script runs `nvm use 24`. If `node -v` reports v22, the harness-injected
+  system node is shadowing it — run `nvm use 24` (yarn is provided through `corepack`).
+- Package manager is **yarn** (`yarn.lock`). Install with `yarn install`.
+
+### Run / build / lint
+- Dev server: the `yarn start` script is `webpack-dev-server --mode development --open --hot`.
+  Two caveats in the cloud VM: `--open` cannot launch a browser (harmless warning), and the
+  default dev-server port is **8080**, which collides with the `population-sim` Go server.
+  Run on a free port instead, e.g. `npx webpack serve --mode development --hot --port 3001`.
+- Build: `yarn build` (webpack, output in `public/`).
+- There is no configured `test` or `lint` script. The committed `.eslintrc.json` predates the
+  React 17+ automatic JSX transform, so a bare `eslint` run reports a false-positive
+  `react/react-in-jsx-scope` error; the actual build uses babel/ts-loader and is unaffected.
+
+### Notes
+- The `@grafana/faro-*` dependencies are vendored as local tarballs in `faro-vendor/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an `AGENTS.md` documenting how to set up, run, build, and lint `elliotkirk` in the Cursor Cloud environment. No application code changed.

## Environment setup verified
- Node 24 (via `nvm`, `.nvmrc`), yarn via corepack.
- `yarn install` → deps installed.
- `yarn build` → webpack build succeeds (`public/`).
- Dev server run on port 3001 (default 8080 collides with the `population-sim` Go server, and `--open` can't launch a browser headless).

## Hello-world
Loaded the site and used the matter-js physics playground — clicking spawns colored balls that fall under gravity.

[elliotkirk_site_demo.mp4](https://cursor.com/agents/bc-52326244-a8da-4d53-8d35-5a02e4bb4714/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felliotkirk_site_demo.mp4)
[elliotkirk physics balls](https://cursor.com/agents/bc-52326244-a8da-4d53-8d35-5a02e4bb4714/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Felliotkirk_balls.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52326244-a8da-4d53-8d35-5a02e4bb4714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52326244-a8da-4d53-8d35-5a02e4bb4714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

